### PR TITLE
Allow for whitelisting non-duo/mfa users instead of the opposite

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ Attributes: {'posix_sysadmins': {'memberUid': "user1", "hi", "user2, ... }}
 :LDAP_CONTROL_BIND_DN="uid=bind-openvpn,ou=logins,dc=mozilla": Bind to that user for attribute checks.
 :LDAP_CONTROL_PASSWORD="": The password for the above user.
 :LDAP_CONTROL_BASE_DN="ou=groups,dc=mozilla": The base DN for the above attribute search.
-:LDAP_DUOSEC_ATTR_VALUE="cn=posix_sysadmins": Will look for that attribute, when checking for DuoSecurity users.
+:LDAP_NO_DUOSEC_ATTR_VALUE="cn=posix_sysadmins": Will look for that attribute, to see if you should bypass Duo authentication.
 :LDAP_DUOSEC_ATTR="memberUid": Will look for that value in the attribute.
 
 Misc scripts

--- a/duo_openvpn.conf.inc
+++ b/duo_openvpn.conf.inc
@@ -34,6 +34,6 @@ LDAP_CONTROL_BASE_DN=""
 # Only users with this attribute can log in at all
 LDAP_MUST_ATTR_VALUE=""
 LDAP_MUST_ATTR=""
-# Only users this attr value can log with Duo
-LDAP_DUOSEC_ATTR_VALUE=""
+# Users this attr value will BYPASS duo auth.
+LDAP_NO_DUOSEC_ATTR_VALUE=""
 LDAP_DUOSEC_ATTR=""

--- a/duo_openvpn.py
+++ b/duo_openvpn.py
@@ -250,7 +250,7 @@ def main():
 			client_ipaddr))
 		return False
 
-# If your password is push/sms/phone/auto then you don't deserve to use this anyway :P
+# If your real password is push/sms/phone/auto then you don't deserve to use this anyway :P
 	if password not in ['push', 'sms', 'phone', 'auto']:
 		if (password.isdigit() and len(password) == 6 or len(password) == 8):
 			passcode = password

--- a/duo_openvpn.py
+++ b/duo_openvpn.py
@@ -250,6 +250,11 @@ def main():
 			client_ipaddr))
 		return False
 
+# If you don't have a password, your username is your password (For ex you might be pasting an OTP as username. That's
+# totally ok!
+	if (len(username) == 0 and username.isdigit():
+		password = username
+
 # If your real password is push/sms/phone/auto then you don't deserve to use this anyway :P
 	if password not in ['push', 'sms', 'phone', 'auto']:
 		if (password.isdigit() and len(password) == 6 or len(password) == 8):


### PR DESCRIPTION
This patch allows also for logging in with OTP as your login (will use it as password too)

THIS NEEDS TESTING ON STAGE.

Note: when deployed, VPN does not need restart. Only new connections are affected.