### PR TITLE
Fix optional stopon arg to send()

### DIFF
--- a/scripts/vpn_kill_users.py
+++ b/scripts/vpn_kill_users.py
@@ -67,7 +67,7 @@ class vpnmgmt():
                 if fd == self.sock:
                     buf = self.sock.recv(1024)
                     data += buf
-            if buf == '' or data.find(stopon) != -1:
+            if buf == '' or stopon is not None and data.find(stopon) != -1:
                 break
         return data
 
@@ -127,3 +127,4 @@ if __name__ == "__main__":
                                 'user': user,
                                 'connected_since': vpn_status[user][2]})
         vpn.kill(user)
+


### PR DESCRIPTION
stopon is technically optional (you'll return via timeout if it doesn't match), but if stopon is NOT set, data.find() explodes because it 'expected a character buffer object'.

This doesn't affect THIS script, but this cost me an hour when I tried reusing the code for a similar task.