### PR TITLE
Indent the kill line so we only kill missing people, not everyone

### DIFF
--- a/scripts/vpn_kill_users.py
+++ b/scripts/vpn_kill_users.py
@@ -126,4 +126,4 @@ if __name__ == "__main__":
                        details={'srcip': vpn_status[user][0].split(':')[0],
                                 'user': user,
                                 'connected_since': vpn_status[user][2]})
-        vpn.kill(user)
+            vpn.kill(user)


### PR DESCRIPTION
The vpn.kill line is outdented outside the if block.  If you run this script as written, everyone's connection dies.