### PR TITLE
Modernize vpn_kill_users against mozdef

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,11 +88,11 @@ The `/scripts` directory contains additional goodies.
 
 vpn_kill_users
 ===============
-If you use `reneg-sec 0` as setting so that OpenVPN does not renegociate (or renegociates very rarely should you use
+If you use `reneg-sec 0` as setting so that OpenVPN does not renegotiate (or renegotiates very rarely should you use
 another setting than 0 but that is still very high), you might still want to automatically disconnect users that you
 have disabled in LDAP.
 
-Run this in a crontab periodically, it'll pool for the users and kill em.
+Run this in a crontab periodically, it'll poll for the users and kill em.
 
 Recommended openvpn server settings:
 

--- a/scripts/vpn_kill_users.py
+++ b/scripts/vpn_kill_users.py
@@ -17,7 +17,7 @@
 import socket
 import mozlibldap
 import imp
-import mozdef
+import mozdef_client as mozdef
 import select
 import sys
 
@@ -29,13 +29,16 @@ for cfg in cfg_path:
         config = imp.load_source('config', cfg)
     except:
         pass
+    else:
+        # use first config file found
+        break
 
 if config is None:
     print("Failed to load config")
     sys.exit(1)
 
 # MozDef Logging
-mdmsg = mozdef.MozDefMsg(config.MOZDEF_HOST, tags=['openvpn', 'killusers'])
+mdmsg = mozdef.MozDefMsg(config.MOZDEF_URL, tags=['openvpn', 'killusers'])
 if config.USE_SYSLOG:
     mdmsg.sendToSyslog = True
 if not config.USE_MOZDEF:


### PR DESCRIPTION
Items from vpn_kill_users were based on mozdef, rather than mozdef_client, and thus not-working in the modern world.

r? @gdestuynder